### PR TITLE
content: add BoxyHQ to authentication and starter kit sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Get your SaaS up and running in no time with this list of free and affordable to
 - [Sveltekit](https://kit.svelte.dev/) - Web development, streamlined.
 
 #### Boilerplate Starter Kits
+- [BoxyHQ Enterprise SaaS Starter Kit](https://github.com/boxyhq/saas-starter-kit) - Enterprise ready, open source, and powered by SAML Jackson.
 - [Just Launch It](https://www.justlaunch.it/) - Sveltekit boilerplate to rapidly build and launch your unicorn Saas.
 - [LaraFast](https://larafast.com) - Laravel boilerplate with ready-to-go components for Payments, Admin, Blog, SEO and more.
 - [ShipFast](https://shipfa.st) - NextJS boilerplate with all you need to build your SaaS.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Get your SaaS up and running in no time with this list of free and affordable to
 - [Cal.com](https://cal.com) - Scheduling Infrastructure for Everyone.
 
 #### Authentification and User Management 👤
+- [BoxyHQ](https://boxyhq.com) - Open source security building blocks for developers. Democratizing enterprise readiness.
 - [Clerk](https://clerk.com) - The most comprehensive User Management Platform
 
 #### CRM


### PR DESCRIPTION
This adds BoxyHQ to the authentication and starter kit sections. Thank you for making and maintaining the list!